### PR TITLE
Add alias for Canon 550D

### DIFF
--- a/sensor_database.csv
+++ b/sensor_database.csv
@@ -245,7 +245,7 @@ Canon;Canon EOS D30;22.7
 Canon;Canon EOS D60;22.7
 Canon;Canon EOS M;22.3
 Canon;Canon EOS Rebel SL1 / 100D;22.3
-Canon;Canon EOS Rebel T2i / 550D;22.3
+Canon;Canon EOS Rebel T2i / Kiss X4 / 550D;22.3
 Canon;Canon EOS Rebel T1i / 500D;22.3
 Canon;Canon EOS Rebel T3 / 1100D;22.2
 Canon;Canon EOS Rebel T3i / 600D;22.3

--- a/sensor_database_detailed.csv
+++ b/sensor_database_detailed.csv
@@ -246,7 +246,7 @@ Canon;EOS D60;22.7 x 15.1 mm;22.7;15.1;3074;2049
 Canon;EOS M;22.3 x 14.9 mm;22.3;14.9;5196;3464
 Canon;EOS Rebel SL1 / 100D;22.3 x 14.9 mm;22.3;14.9;5196;3464
 Canon;EOS Rebel T1i / 500D;22.3 x 14.9 mm;22.3;14.9;4752;3168
-Canon;EOS Rebel T2i / 550D;22.3 x 14.9 mm;22.3;14.9;5196;3464
+Canon;EOS Rebel T2i / Kiss X4 / 550D;22.3 x 14.9 mm;22.3;14.9;5196;3464
 Canon;EOS Rebel T3 / 1100D;22.2 x 14.8 mm;22.2;14.8;4278;2852
 Canon;EOS Rebel T3i / 600D;22.3 x 14.9 mm;22.3;14.9;5196;3464
 Canon;EOS Rebel T4i / 650D;22.3 x 14.9 mm;22.3;14.9;5196;3464


### PR DESCRIPTION
Canon 550D is also known as Kiss X4