### PR TITLE
Add Panasonic Lumix G7

### DIFF
--- a/sensor_database.csv
+++ b/sensor_database.csv
@@ -2319,6 +2319,7 @@ Panasonic;Panasonic Lumix DMC-G2;17.3
 Panasonic;Panasonic Lumix DMC-G3;17.3
 Panasonic;Panasonic Lumix DMC-G5;17.3
 Panasonic;Panasonic Lumix DMC-G6;17.3
+Panasonic;Panasonic Lumix DMC-G7;17.3
 Panasonic;Panasonic Lumix DMC-GF1;17.3
 Panasonic;Panasonic Lumix DMC-GF2;17.3
 Panasonic;Panasonic Lumix DMC-GF3;17.3

--- a/sensor_database_detailed.csv
+++ b/sensor_database_detailed.csv
@@ -2318,6 +2318,7 @@ Panasonic;Lumix DMC-G2;Four Thirds (17.3 x 13 mm);17.3;13;4011;3016
 Panasonic;Lumix DMC-G3;Four Thirds (17.3 x 13 mm);17.3;13;4585;3447
 Panasonic;Lumix DMC-G5;Four Thirds (17.3 x 13 mm);17.3;13;4620;3474
 Panasonic;Lumix DMC-G6;Four Thirds (17.3 x 13 mm);17.3;13;4620;3474
+Panasonic;Lumix DMC-G7;Four Thirds (17.3 x 13 mm);17.3;13;4612;3468
 Panasonic;Lumix DMC-GF1;Four Thirds (17.3 x 13 mm);17.3;13;4011;3016
 Panasonic;Lumix DMC-GF2;Four Thirds (17.3 x 13 mm);17.3;13;4011;3016
 Panasonic;Lumix DMC-GF3;Four Thirds (17.3 x 13 mm);17.3;13;4011;3016


### PR DESCRIPTION
Adding sensor info for this camera. It is very similar to the G7, but with slightly different sensor resolution.

Reference: https://www.digicamdb.com/specs/panasonic_lumix-dmc-g7/

