### PR TITLE
Add Panasonic Lumix DC-GH5

### DIFF
--- a/sensor_database.csv
+++ b/sensor_database.csv
@@ -2330,6 +2330,7 @@ Panasonic;Panasonic Lumix DMC-GH1;17.3
 Panasonic;Panasonic Lumix DMC-GH2;17.3
 Panasonic;Panasonic Lumix DMC-GH3;17.3
 Panasonic;Panasonic Lumix DMC-GH4;17.3
+Panasonic;Panasonic Lumix DMC-GH5;17.3
 Panasonic;Panasonic Lumix DMC-GM1;17.3
 Panasonic;Panasonic Lumix DMC-GM5;17.3
 Panasonic;Panasonic Lumix DMC-GX1;17.3

--- a/sensor_database_detailed.csv
+++ b/sensor_database_detailed.csv
@@ -2329,6 +2329,7 @@ Panasonic;Lumix DMC-GH1;Four Thirds (17.3 x 13 mm);17.3;13;4011;3016
 Panasonic;Lumix DMC-GH2;Four Thirds (17.3 x 13 mm);17.3;13;4620;3474
 Panasonic;Lumix DMC-GH3;Four Thirds (17.3 x 13 mm);17.3;13;4620;3474
 Panasonic;Lumix DMC-GH4;Four Thirds (17.3 x 13 mm);17.3;13;4620;3474
+Panasonic;Lumix DMC-GH5;Four Thirds (17.3 x 13 mm);17.3;13;5196;3907
 Panasonic;Lumix DMC-GM1;Four Thirds (17.3 x 13 mm);17.3;13;4612;3468
 Panasonic;Lumix DMC-GM5;Four Thirds (17.3 x 13 mm);17.3;13;4612;3468
 Panasonic;Lumix DMC-GX1;Four Thirds (17.3 x 13 mm);17.3;13;4612;3468


### PR DESCRIPTION
Adding Lumix GH5.

Width: 17.3mm
Resolution: 5196 x 3907

Reference: https://www.digicamdb.com/specs/panasonic_lumix-dc-gh5/

Thanks! (Sorry for the many pull requests!)