### PR TITLE
Update sensor_database_detailed.csv

### DIFF
--- a/sensor_database_detailed.csv
+++ b/sensor_database_detailed.csv
@@ -2302,6 +2302,7 @@ Panasonic,Lumix DMC-FZ200,"1/2.3"" (~ 6.16 x 4.62 mm)",6.16,4.62,4011,3016
 Panasonic,Lumix DMC-FZ28,"1/2.33"" (~ 6.08 x 4.56 mm)",6.08,4.56,3665,2756
 Panasonic,Lumix DMC-FZ3,"1/3.2"" (~ 4.5 x 3.37 mm)",4.5,3.37,2005,1496
 Panasonic,Lumix DMC-FZ30,"1/1.8"" (~ 7.11 x 5.33 mm)",7.11,5.33,3262,2453
+Panasonic,Lumix DMC-FZ30,"1/1.8"" (~ 7.11 x 5.33 mm)",7.11,5.33,3262,2453
 Panasonic,Lumix DMC-FZ35,"1/2.33"" (~ 6.08 x 4.56 mm)",6.08,4.56,4011,3016
 Panasonic,Lumix DMC-FZ38,"1/2.33"" (~ 6.08 x 4.56 mm)",6.08,4.56,4011,3016
 Panasonic,Lumix DMC-FZ4,"1/2.5"" (~ 5.75 x 4.32 mm)",5.75,4.32,2306,1734


### PR DESCRIPTION
Added Panasonic Lumix DMC-FZ300 SLR-like (bridge) Small Sensor Superzoom camera: Panasonic,Lumix DMC-FZ300,"1/2.3"" (~ 6.16 x 4.62 mm)",6.17,4.62,4011,3016