### PR TITLE
Update sensor_database.csv

### DIFF
--- a/sensor_database.csv
+++ b/sensor_database.csv
@@ -2306,6 +2306,7 @@ Panasonic,Panasonic Lumix DMC-FZ200,6.16
 Panasonic,Panasonic Lumix DMC-FZ28,6.08
 Panasonic,Panasonic Lumix DMC-FZ3,4.5
 Panasonic,Panasonic Lumix DMC-FZ30,7.11
+Panasonic,Panasonic Lumix DMC-FZ300,6.16
 Panasonic,Panasonic Lumix DMC-FZ35,6.08
 Panasonic,Panasonic Lumix DMC-FZ38,6.08
 Panasonic,Panasonic Lumix DMC-FZ4,5.75


### PR DESCRIPTION
Added Panasonic Lumix DMC-FZ300 SLR-like (bridge) Small Sensor Superzoom camera: Panasonic,Panasonic Lumix DMC-FZ300,6.16
- according https://www.digicamdb.com/specs/panasonic_lumix-dmc-fz300/